### PR TITLE
fix: switch npm publishing to GitHub OIDC trusted publisher

### DIFF
--- a/.github/scripts/pub.sh
+++ b/.github/scripts/pub.sh
@@ -47,7 +47,7 @@ if [ "$AFFECTED" != "" ]; then
   while IFS= read -r -d $' ' lib; do
     if [ "$DRY_RUN" == "False" ]; then
       echo "Publishing $lib"
-      npm publish "$ROOT_DIR/dist/libs/${lib}" --access=public
+      npm publish "$ROOT_DIR/dist/libs/${lib}" --access=public --provenance
     else
       echo "Dry Run, not publishing $lib"
     fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,9 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - uses: nrwl/nx-set-shas@v3
       - run: npm ci

--- a/.github/workflows/build-test-and-release.yml
+++ b/.github/workflows/build-test-and-release.yml
@@ -9,18 +9,19 @@ jobs:
     name: Release
     if: "!contains(github.event.head_commit.author.name, 'GitHub Action')"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
         fetch-depth: 3
 
-    - name: 'Configure NPM'
-      run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
-      env:
-        NODE_AUTH_TOKEN: ${{secrets.FIREBEND_NPM_KEY}}
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        registry-url: 'https://registry.npmjs.org'
 
-    - run: npm whoami
     - run: echo "NX_HEAD=`git rev-parse HEAD`" >> $GITHUB_ENV
     - run: echo "NX_BASE=`git rev-parse HEAD~1`" >> $GITHUB_ENV
     - run: echo $NX_HEAD
@@ -43,7 +44,7 @@ jobs:
         git commit -m "Release [skip-ci]" --no-verify
 
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.8.0
       with:
         github_token: ${{secrets.GIT_TOKEN}}
         branch: ${{ github.ref }}


### PR DESCRIPTION
## Summary
- Switch npm publishing from a long-lived `FIREBEND_NPM_KEY` token to GitHub Actions OIDC trusted publishing.
- Add `permissions: id-token: write` to the release job.
- Replace `.npmrc` auth-token setup with `actions/setup-node@v4` and `registry-url`.
- Add `--provenance` to `npm publish` for verifiable provenance attestation.
- Update `actions/checkout` to v4 and pin `ad-m/github-push-action` to v0.8.0.
- Modernize `build-and-test.yml` with `actions/checkout@v4` and `actions/setup-node@v4` (node 20).

## Test plan
- [ ] Merge and verify the next release publishes to npm successfully.

Generated with [Devin](https://devin.ai)