### PR TITLE
ci: always publish all libs on main merges

### DIFF
--- a/.github/scripts/pub.sh
+++ b/.github/scripts/pub.sh
@@ -47,7 +47,7 @@ if [ "$AFFECTED" != "" ]; then
   while IFS= read -r -d $' ' lib; do
     if [ "$DRY_RUN" == "False" ]; then
       echo "Publishing $lib"
-      npm publish "$ROOT_DIR/dist/libs/${lib}" --access=public
+      npm publish "$ROOT_DIR/dist/libs/${lib}" --access=public --provenance
     else
       echo "Dry Run, not publishing $lib"
     fi

--- a/.github/scripts/pub.sh
+++ b/.github/scripts/pub.sh
@@ -25,8 +25,8 @@ echo "Release Type: $RELEASE_TYPE"
 DRY_RUN=${DRY_RUN:-"False"}
 echo "Dry Run: $DRY_RUN"
 
-AFFECTED=$(node_modules/.bin/nx show projects --affected --type=lib)
-echo "Affected Libraries: $AFFECTED"
+AFFECTED=$(node_modules/.bin/nx show projects --type=lib)
+echo "Libraries to publish: $AFFECTED"
 
 if [ "$AFFECTED" != "" ]; then
   cd "$PARENT_DIR"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,9 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - uses: nrwl/nx-set-shas@v3
       - run: npm ci

--- a/.github/workflows/build-test-and-release.yml
+++ b/.github/workflows/build-test-and-release.yml
@@ -41,7 +41,11 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add -A
-        git commit -m "Release [skip-ci]" --no-verify
+        if git diff --cached --quiet; then
+          echo "No changes to commit after release"
+        else
+          git commit -m "Release [skip-ci]" --no-verify
+        fi
 
     - name: Push changes
       uses: ad-m/github-push-action@v0.8.0

--- a/.github/workflows/build-test-and-release.yml
+++ b/.github/workflows/build-test-and-release.yml
@@ -9,18 +9,19 @@ jobs:
     name: Release
     if: "!contains(github.event.head_commit.author.name, 'GitHub Action')"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
         fetch-depth: 3
 
-    - name: 'Configure NPM'
-      run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
-      env:
-        NODE_AUTH_TOKEN: ${{secrets.FIREBEND_NPM_KEY}}
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        registry-url: 'https://registry.npmjs.org'
 
-    - run: npm whoami
     - run: echo "NX_HEAD=`git rev-parse HEAD`" >> $GITHUB_ENV
     - run: echo "NX_BASE=`git rev-parse HEAD~1`" >> $GITHUB_ENV
     - run: echo $NX_HEAD
@@ -43,7 +44,7 @@ jobs:
         git commit -m "Release [skip-ci]" --no-verify
 
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.8.0
       with:
         github_token: ${{secrets.GIT_TOKEN}}
         branch: ${{ github.ref }}


### PR DESCRIPTION
## Summary
The previous release workflow fix landed, but no library was published because the change was only in `.github/` files, which `nx affected` does not associate with the `web-socket-client` library.

This PR changes the release script to publish all libraries on every merge to `main` instead of only affected ones. Since this workspace has a single library (`web-socket-client`), this is the same effective behavior and avoids silent no-op releases.

Also makes the post-publish `git commit` step resilient when there are no changes to commit.

## Test plan
- [ ] Merge and verify the next `main` release publishes `web-socket-client` to npm.

Generated with [Devin](https://devin.ai)