### PR TITLE
fix: upgrade to Node 24 to fix OIDC trusted publishing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - uses: nrwl/nx-set-shas@v3
       - run: npm ci

--- a/.github/workflows/build-test-and-release.yml
+++ b/.github/workflows/build-test-and-release.yml
@@ -19,8 +19,9 @@ jobs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
         registry-url: 'https://registry.npmjs.org'
+        package-manager-cache: false
 
     - run: echo "NX_HEAD=`git rev-parse HEAD`" >> $GITHUB_ENV
     - run: echo "NX_BASE=`git rev-parse HEAD~1`" >> $GITHUB_ENV

--- a/libs/web-socket-client/package.json
+++ b/libs/web-socket-client/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@firebend/control-tower-web-socket-client",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A library receiving Control Tower Platform real time events over a web socket",
   "homepage": "https://github.com/firebend/control-tower-web-sockets#readme",
   "bugs": {
     "url": "https://github.com/firebend/control-tower-web-sockets/issues"
   },
-  "repository": "github:firebend/control-tower-web-sockets",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/firebend/control-tower-web-sockets.git"
+  },
   "license": "MIT",
   "dependencies": {
     "@microsoft/signalr": "8.0.7"


### PR DESCRIPTION
## Summary

- Upgrades Node.js from 20 to 24 in both CI workflows
- Fixes the `E404 'not in this registry'` error during `npm publish` with OIDC trusted publishing

## Root Cause

npm Trusted Publishing (OIDC) requires **npm CLI v11.5.1 or later**. Node 20 ships with npm v10, which does not support the required OIDC handshake protocol. When the handshake fails silently, the registry treats the request as anonymous, and anonymous `PUT` requests return a misleading 404 error.

Node 24 (LTS) ships with npm v11, which correctly implements the OIDC handshake and fixes the publish failure.

Reference: [npm/cli#8976](https://github.com/npm/cli/issues/8976)

#### Test plan
- [ ] Merge this PR
- [ ] Verify the `Merge on Main` workflow succeeds and publishes the package

Generated with [Devin](https://devin.ai)