### PR TITLE
fix: sync published version and update push action

### DIFF
--- a/.github/workflows/build-test-and-release.yml
+++ b/.github/workflows/build-test-and-release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -49,9 +50,9 @@ jobs:
         fi
 
     - name: Push changes
-      uses: ad-m/github-push-action@v0.8.0
+      uses: ad-m/github-push-action@v1.1.0
       with:
-        github_token: ${{secrets.GIT_TOKEN}}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ github.ref }}
         tags: true
         force: true

--- a/libs/web-socket-client/package.json
+++ b/libs/web-socket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebend/control-tower-web-socket-client",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A library receiving Control Tower Platform real time events over a web socket",
   "homepage": "https://github.com/firebend/control-tower-web-sockets#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- Sync `libs/web-socket-client/package.json` to version `1.7.3` (already published to npm)
- Upgrade `ad-m/github-push-action` from `v0.8.0` to `v1.1.0` for Node 24 compatibility
- Add `contents: write` permission so the workflow can push commits and tags
- Switch from `secrets.GIT_TOKEN` to `secrets.GITHUB_TOKEN`

## Root Cause

The publish step succeeded with version `1.7.3`, but the workflow failed at the push step with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
```

The `ad-m/github-push-action@v0.8.0` action runs on Node 20 and was using the `GIT_TOKEN` secret, which appears to be invalid or expired. Version `v1.1.0` of the action upgrades to Node 24 and works with the built-in `GITHUB_TOKEN`.

## Important Note

`GITHUB_TOKEN` requires the repository to allow **Read and write permissions** for workflows:
`Settings > Actions > General > Workflow permissions > Read and write permissions`

#### Test plan
- [ ] Merge this PR
- [ ] Verify the `Merge on Main` workflow succeeds and pushes the next version bump back to `main`

Generated with [Devin](https://devin.ai)